### PR TITLE
Adding missing requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Creating ZnapZend Debian packages
 
 Install required packages:
 ```sh
-apt install git devscripts dh-systemd
+apt install git devscripts dh-systemd unzip
 ```
 
 Build debs:


### PR DESCRIPTION
Package 'unzip' was missing. It is required for some cpan modules.