### PR TITLE
Pull znapzend 0.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,11 @@ debuild --no-tgz-check -us -uc
 ```
 
 Resulting packages are in parent directory
+```sh
 cd ..
+```
 
 Install:
+```sh
 apt install ./znapzend_0.21.0-1_amd64.deb
+```

--- a/README.md
+++ b/README.md
@@ -17,10 +17,14 @@ Build debs:
 ```sh
 git clone https://github.com/Gregy/znapzend-debian.git
 cd znapzend-debian
-git clone -b v0.20.0 https://github.com/oetiker/znapzend
+git clone -b v0.21.0 https://github.com/oetiker/znapzend
 cp -r debian/ znapzend
 cd znapzend
 debuild --no-tgz-check -us -uc
 ```
 
 Resulting packages are in parent directory
+cd ..
+
+Install:
+apt install ./znapzend_0.21.0-1_amd64.deb

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-znapzend (0.20.0-1) UNRELEASED; urgency=medium
+znapzend (0.21.0-1) UNRELEASED; urgency=medium
 
   * Experimental package
 
- -- Petr Gregor <gregy@gregy.cz>  Tue, 10 Jul 2018 10:49:00 +0100
+ -- Petr Gregor <gregy@gregy.cz>  Tue, 20 Sept 2021 16:15:00 +0000


### PR DESCRIPTION
Tested in Debian 10 Buster 4.19.0-17-amd64 SMP Debian 4.19.194-1 (2021-06-10)
Only broken [new] feature is the optional e-mail transmission of failure messages. This is fixed in the master branch as of this morning, but not yet in a release.