### PR TITLE
Update README to checkout latest znapzend version

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Build debs:
 ```sh
 git clone https://github.com/Gregy/znapzend-debian.git
 cd znapzend-debian
-git clone -b v0.21.0 https://github.com/oetiker/znapzend
+git clone -b v0.21.1 https://github.com/oetiker/znapzend
 cp -r debian/ znapzend
 cd znapzend
 debuild --no-tgz-check -us -uc


### PR DESCRIPTION
I forgot to update the README in the last pull request.